### PR TITLE
break back content plugin into multiple forms and clean up for cdl use

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,15 +1,21 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from submission import models
+from submission.models import Article, Licence, Section, FieldAnswer, Field
 from review.logic import render_choices
 from utils.forms import KeywordModelForm
-from core import models as core_models, model_utils
+from core.models import Account
+from core.model_utils import DateTimePickerInput
 
+
+class DepositAgreementForm(forms.Form):
+    deposit_agreement = forms.BooleanField(
+        help_text="The author(s) of this article have signed a PDF, clicked through a form, or otherwise documented agreement to the journal's copyright agreement, which grants the journal permission to publish this article. (The agreement should match the one on file with eScholarship staff, which you can view here. If you have questions please contact eScholarship.)"
+    )
 
 class PublicationInfo(forms.ModelForm):
     class Meta:
-        model = models.Article
+        model = Article
         fields = (
             'date_accepted',
             'date_published',
@@ -19,15 +25,14 @@ class PublicationInfo(forms.ModelForm):
             'render_galley',
         )
         help_texts = {
-            'render_galley': 'Render Galleys are displayed on the Article page'
-                             ' generally this will be an XML or HTML Galley.',
+            'render_galley': 'Render Galleys are displayed on the Article page',
             'page_numbers': 'Tis is a free text field, generally page numbers'
                             ' look like 10 or 10-16',
             'peer_reviewed': 'If this article has been peer reviewed prior to'
                              'being loaded into Janeway check this box.'
         }
         widgets = {
-            'date_accepted': model_utils.DateTimePickerInput,
+            'date_accepted': DateTimePickerInput,
         }
 
     def __init__(self, *args, **kwargs):
@@ -40,7 +45,7 @@ class PublicationInfo(forms.ModelForm):
 
 class RemoteArticle(forms.ModelForm):
     class Meta:
-        model = models.Article
+        model = Article
         fields = ('is_remote', 'remote_url')
 
 
@@ -48,15 +53,19 @@ class RemoteParse(forms.Form):
     url = forms.CharField(required=True, label="Enter a URL or a DOI.")
     mode = forms.ChoiceField(required=True, choices=(('url', 'URL'), ('doi', 'DOI')))
 
-
 class ArticleInfo(KeywordModelForm):
 
     class Meta:
-        model = models.Article
+        model = Article
         fields = (
-        'title', 'subtitle', 'abstract', 'non_specialist_summary',
-        'language', 'section', 'license', 'primary_issue',
-        'page_numbers', 'is_remote', 'remote_url', 'peer_reviewed')
+            'title',
+            'subtitle',
+            'abstract',
+            'language',
+            'section',
+            'license',
+            'page_numbers',
+        )
         widgets = {
             'title': forms.TextInput(attrs={'placeholder': _('Title')}),
         }
@@ -66,116 +75,113 @@ class ArticleInfo(KeywordModelForm):
         submission_summary = kwargs.pop('submission_summary', None)
         journal = kwargs.pop('journal', None)
 
-        super(ArticleInfo, self).__init__(*args, **kwargs)
         if 'instance' in kwargs:
             article = kwargs['instance']
-            self.fields['section'].queryset = models.Section.objects.filter(
-                journal=article.journal,
-            )
-            self.fields['license'].queryset = models.Licence.objects.filter(
-                journal=article.journal,
-                available_for_submission=True,
+            journal = article.journal
+        else:
+            article = None
+
+        super(ArticleInfo, self).__init__(*args, **kwargs)
+        if journal:
+            self.fields['section'].queryset = Section.objects.filter(
+                journal=journal,
             )
             self.fields['section'].required = True
+            self.fields['license'].queryset = Licence.objects.filter(
+                journal=journal,
+                available_for_submission=True,
+            )
             self.fields['license'].required = True
-            self.fields['primary_issue'].queryset = article.journal.issues
 
-            abstracts_required = article.journal.get_setting(
+            abstracts_required = journal.get_setting(
                 'general',
                 'abstract_required',
             )
-
             if abstracts_required:
                 self.fields['abstract'].required = True
 
-            if submission_summary:
-                self.fields['non_specialist_summary'].required = True
+            if not journal.submissionconfiguration.subtitle:
+                self.fields.pop('subtitle')
 
-            # Pop fields based on journal.submissionconfiguration
-            if journal:
-                if not journal.submissionconfiguration.subtitle:
-                    self.fields.pop('subtitle')
+            if not journal.submissionconfiguration.abstract:
+                self.fields.pop('abstract')
 
-                if not journal.submissionconfiguration.abstract:
-                    self.fields.pop('abstract')
+            if not journal.submissionconfiguration.language:
+                self.fields.pop('language')
 
-                if not journal.submissionconfiguration.language:
-                    self.fields.pop('language')
+            if not journal.submissionconfiguration.license:
+                self.fields.pop('license')
 
-                if not journal.submissionconfiguration.license:
-                    self.fields.pop('license')
+            if not journal.submissionconfiguration.keywords:
+                self.fields.pop('keywords')
 
-                if not journal.submissionconfiguration.keywords:
-                    self.fields.pop('keywords')
+            if not journal.submissionconfiguration.section:
+                self.fields.pop('section')
 
-                if not journal.submissionconfiguration.section:
-                    self.fields.pop('section')
+        if submission_summary:
+            self.fields['non_specialist_summary'].required = True
 
-            # Add additional fields
-            if elements:
-                for element in elements:
-                    if element.kind == 'text':
-                        self.fields[element.name] = forms.CharField(
-                            widget=forms.TextInput(attrs={'div_class': element.width}),
-                            required=element.required)
-                    elif element.kind == 'textarea':
-                        self.fields[element.name] = forms.CharField(widget=forms.Textarea,
-                                                                    required=element.required)
-                    elif element.kind == 'date':
-                        self.fields[element.name] = forms.CharField(
-                            widget=forms.DateInput(attrs={'class': 'datepicker', 'div_class': element.width}),
-                            required=element.required)
+        if elements:
+            for element in elements:
+                if element.kind == 'text':
+                    self.fields[element.name] = forms.CharField(
+                        widget=forms.TextInput(attrs={'div_class': element.width}),
+                        required=element.required)
+                elif element.kind == 'textarea':
+                    self.fields[element.name] = forms.CharField(widget=forms.Textarea,
+                                                                required=element.required)
+                elif element.kind == 'date':
+                    self.fields[element.name] = forms.CharField(
+                        widget=forms.DateInput(attrs={'class': 'datepicker', 'div_class': element.width}),
+                        required=element.required)
 
-                    elif element.kind == 'select':
-                        choices = render_choices(element.choices)
-                        self.fields[element.name] = forms.ChoiceField(
-                            widget=forms.Select(attrs={'div_class': element.width}), choices=choices,
-                            required=element.required)
+                elif element.kind == 'select':
+                    choices = render_choices(element.choices)
+                    self.fields[element.name] = forms.ChoiceField(
+                        widget=forms.Select(attrs={'div_class': element.width}), choices=choices,
+                        required=element.required)
 
-                    elif element.kind == 'email':
-                        self.fields[element.name] = forms.EmailField(
-                            widget=forms.TextInput(attrs={'div_class': element.width}),
-                            required=element.required)
-                    elif element.kind == 'check':
-                        self.fields[element.name] = forms.BooleanField(
-                            widget=forms.CheckboxInput(attrs={'is_checkbox': True}),
-                            required=element.required)
+                elif element.kind == 'email':
+                    self.fields[element.name] = forms.EmailField(
+                        widget=forms.TextInput(attrs={'div_class': element.width}),
+                        required=element.required)
+                elif element.kind == 'check':
+                    self.fields[element.name] = forms.BooleanField(
+                        widget=forms.CheckboxInput(attrs={'is_checkbox': True}),
+                        required=element.required)
 
-                    self.fields[element.name].help_text = element.help_text
-                    self.fields[element.name].label = element.name
+                self.fields[element.name].help_text = element.help_text
+                self.fields[element.name].label = element.name
 
-                    if article:
-                        try:
-                            check_for_answer = models.FieldAnswer.objects.get(field=element, article=article)
-                            self.fields[element.name].initial = check_for_answer.answer
-                        except models.FieldAnswer.DoesNotExist:
-                            pass
+                if article:
+                    try:
+                        check_for_answer = FieldAnswer.objects.get(field=element, article=article)
+                        self.fields[element.name].initial = check_for_answer.answer
+                    except FieldAnswer.DoesNotExist:
+                        pass
 
     def save(self, commit=True, request=None):
-        article = super(ArticleInfo, self).save(commit=False)
+        article = super(ArticleInfo, self).save(commit=commit)
 
         if request:
-            additional_fields = models.Field.objects.filter(journal=request.journal)
+            additional_fields = Field.objects.filter(journal=request.journal)
 
             for field in additional_fields:
                 answer = request.POST.get(field.name, None)
                 if answer:
                     try:
-                        field_answer = models.FieldAnswer.objects.get(article=article, field=field)
+                        field_answer = FieldAnswer.objects.get(article=article, field=field)
                         field_answer.answer = answer
                         field_answer.save()
-                    except models.FieldAnswer.DoesNotExist:
-                        field_answer = models.FieldAnswer.objects.create(article=article, field=field, answer=answer)
+                    except FieldAnswer.DoesNotExist:
+                        field_answer = FieldAnswer.objects.create(article=article, field=field, answer=answer)
 
             request.journal.submissionconfiguration.handle_defaults(article)
-
-        if commit:
-            article.save()
 
         return article
 
 
 class ExistingAuthor(forms.Form):
     author = forms.ModelChoiceField(
-        queryset=core_models.Account.objects.all()
+        queryset=Account.objects.all()
     )

--- a/forms.py
+++ b/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from django.urls import reverse_lazy
+from django.utils.text import format_lazy
 
 from submission.models import Article, Licence, Section, FieldAnswer, Field
 from review.logic import render_choices
@@ -10,7 +12,7 @@ from core.model_utils import DateTimePickerInput
 
 class DepositAgreementForm(forms.Form):
     deposit_agreement = forms.BooleanField(
-        help_text="The author(s) of this article have signed a PDF, clicked through a form, or otherwise documented agreement to the journal's copyright agreement, which grants the journal permission to publish this article. (The agreement should match the one on file with eScholarship staff, which you can view here. If you have questions please contact eScholarship.)"
+        help_text=format_lazy("The author(s) of this article have signed a PDF, clicked through a form, or otherwise documented agreement to the journal's copyright agreement, which grants the journal permission to publish this article. (The agreement should match the one on file with eScholarship staff, which you can <a href='{}'>view here</a>. If you have questions please <a href='https://help.escholarship.org/support/tickets/new'>contact eScholarship</a>.)",  reverse_lazy('journal_submissions'))
     )
 
 class PublicationInfo(forms.ModelForm):

--- a/templates/back_content/article.html
+++ b/templates/back_content/article.html
@@ -19,56 +19,49 @@
     <section class="content">
         <div class="row expanded">
             <div class="large-12 columns box">
+                <form method="POST">
+                {% csrf_token %}
                 <div class="title-area">
                     <h2 id="section-one">1. Article Metadata</h2>
                 </div>
                 <div class="content">
-                    <form method="POST">
-                        {% csrf_token %}
-                        <div class="large-12 columns">
-                            <label for="id_title">{% trans "Title" %}</label>
-                            {{ article_form.title }}
-                            {{ article_form.title.errors }}
-                        </div>
-                        <div class="large-12 columns">
-                            <label for="id_abstract">
-                                {% trans "Abstract" %}{% if form.abstract.field.required %}*{% endif %}</label>
-                            {{ article_form.abstract }}
-                            {{ article_form.abstract.errors }}
-                        </div>
-                        <div class="large-4 columns">
-                            <label for="id_language">{% trans "Language" %}</label>
-                            {{ article_form.language }}
-                            {{ article_form.language.errors }}
-                        </div>
-                        <div class="large-4 columns">
-                            <label for="id_section">{% trans "Section" %}</label>
-                            {{ article_form.section }}
-                            {{ article_form.section.errors }}
-                        </div>
-                        <div class="large-4 columns error">
-                            <label for="id_license">{% if article_form.license.errors %}
-                                <span style="color: red;">{% endif %}{% trans "License" %}
-                                {% if article_form.license.errors %}</span>{% endif %}
-                                {% if article_form.license.field.required %}*{% endif %}</label>
-                            {{ article_form.license }}
-                            {{ article_form.license.errors }}
-                        </div>
-                        <div class="large-12 columns">
-                            <label for="id_keywords">Keywords</label>
-                            <input type="text" id="id_keywords" name="keywords" value="
-                                    {% if article_form.cleaned_data.keywords %}{{ article_form.cleaned_data.keywords }}{% else %}{% for keyword in article.keywords.all %}{{ keyword.word }}{% if not forloop.last %},{% endif %}{% endfor %}{% endif %}"/>
-                            Hit Enter to add a new keyword.
-                        </div>
+                    <div class="large-12 columns">
+                        <label for="id_title">{% trans "Title" %}</label>
+                        {{ article_form.title }}
+                        {{ article_form.title.errors }}
+                    </div>
+                    <div class="large-12 columns">
+                        <label for="id_abstract">
+                            {% trans "Abstract" %}{% if form.abstract.field.required %}*{% endif %}</label>
+                        {{ article_form.abstract }}
+                        {{ article_form.abstract.errors }}
+                    </div>
+                    <div class="large-4 columns">
+                        <label for="id_language">{% trans "Language" %}</label>
+                        {{ article_form.language }}
+                        {{ article_form.language.errors }}
+                    </div>
+                    <div class="large-4 columns">
+                        <label for="id_section">{% trans "Section" %}</label>
+                        {{ article_form.section }}
+                        {{ article_form.section.errors }}
+                    </div>
+                    <div class="large-4 columns error">
+                        <label for="id_license">{% if article_form.license.errors %}
+                            <span style="color: red;">{% endif %}{% trans "License" %}
+                            {% if article_form.license.errors %}</span>{% endif %}
+                            {% if article_form.license.field.required %}*{% endif %}</label>
+                        {{ article_form.license }}
+                        {{ article_form.license.errors }}
+                    </div>
+                    <div class="large-12 columns">
+                        <label for="id_keywords">Keywords</label>
+                        <input type="text" id="id_keywords" name="keywords" value="
+                                {% if article_form.cleaned_data.keywords %}{{ article_form.cleaned_data.keywords }}{% else %}{% for keyword in article.keywords.all %}{{ keyword.word }}{% if not forloop.last %},{% endif %}{% endfor %}{% endif %}"/>
+                        Hit Enter to add a new keyword.
+                    </div>
 
-                        {% include "admin/elements/submission/additional_fields.html" with form=article_form additional_fields=additional_fields %}
-
-                        <div class="large-12 columns">
-                            <button class="success button pull-right" type="submit" name="save_section_1"><i
-                                    class="fa fa-check">&nbsp;</i>{% trans "Save Section 1" %}
-                            </button>
-                        </div>
-                    </form>
+                    {% include "admin/elements/submission/additional_fields.html" with form=article_form additional_fields=additional_fields %}
                 </div>
                 <div class="title-area">
                     <h2 id="section-two">2. Article Authors</h2>
@@ -80,60 +73,51 @@
                         {% include "admin/elements/submit/author.html" %}
                         <p>{% trans "If you know of an existing author, you can search for them." %}</p>
                         <a href="{% url 'bc_article_authors' article.pk %}" class="small success button">Search Accounts for Authors</a>
-
                     </div>
                     <div class="large-5 columns" data-equalizer-watch>
                         <h4>{% trans "Current Authors" %}</h4>
                         <div class="row">
                             <div class="large-12 columns">
-                                <form method="POST">
-                                {% csrf_token %}
-                                    <table class="small scroll">
-                                        <thead>
-                                        <tr>
-                                            <th></th>
-                                            <th>{% trans "Name" %}</th>
-                                            <th>{% trans "Email" %}</th>
-                                            <th></th>
-                                            <th></th>
+                                <table class="small scroll">
+                                    <thead>
+                                    <tr>
+                                        <th></th>
+                                        <th>{% trans "Name" %}</th>
+                                        <th>{% trans "Email" %}</th>
+                                        <th></th>
+                                        <th></th>
+                                    </tr>
+                                    </thead>
+                                    <tbody id="sortable">
+                                    {% for order in article.articleauthororder_set.all %}
+                                        <tr id="authors-{{ order.author.pk }}">
+                                            <td><i class="fa fa-sort"></i></td>
+                                            <td>{{ order.author.full_name }}</td>
+                                            <td>{{ order.author.email }}</td>
+                                            <td>
+                                                <button name="set_main" value="{{ order.author.pk }}" class="tiny button">Set as Main</button>
+                                            </td>
+                                            <td>
+                                                <button name="remove_author" value="{{ order.author.pk }}" class="tiny alert button">Remove</button>
+                                            </td>
                                         </tr>
-                                        </thead>
-                                        <tbody id="sortable">
-                                        {% for order in article.articleauthororder_set.all %}
-                                            <tr id="authors-{{ order.author.pk }}">
-                                                <td><i class="fa fa-sort"></i></td>
-                                                <td>{{ order.author.full_name }}</td>
-                                                <td>{{ order.author.email }}</td>
-                                                <td>
-                                                    <button name="set_main" value="{{ order.author.pk }}" class="tiny button">Set as Main</button>
-                                                </td>
-                                                <td>
-                                                  <button name="remove_author" value="{{ order.author.pk }}" class="tiny alert button">Remove</button>
-                                                </td>
-                                            </tr>
-                                            {% empty %}
-                                            <tr>
-                                                <td colspan="3">{% trans "No authors yet, add one!" %}</td>
-                                            </tr>
-                                        {% endfor %}
-                                    </table>
-                                </form>
+                                        {% empty %}
+                                        <tr>
+                                            <td colspan="3">{% trans "No authors yet, add one!" %}</td>
+                                        </tr>
+                                    {% endfor %}
+                                </table>
                                 <hr/>
-                                <form method="POST">
-                                    {% csrf_token %}
-                                    <p>{% trans "You are required to select a main author, this author will receive the communications regarding your articles process through our systems. This does not have to be you." %}</p>
-                                    <label for="main-author">{% trans "Select main author" %}:</label>
-                                    <select class="form-control" id="main-author" name="main-author" required>
-                                        <option value="">---------</option>
-                                        {% for author in article.authors.all %}
-                                            <option value="{{ author.pk }}"
-                                                    {% if article.correspondence_author.pk == author.pk %}selected{% endif %}>{{ author.full_name }}</option>
-                                        {% endfor %}
-                                    </select>
-                                    <br/>
-                                    <button class="success button pull-right" type="submit" name="save_section_2"><i
-                                            class="fa fa-check">&nbsp;</i>{% trans "Save Section 2" %}</button>
-                                </form>
+                                <p>{% trans "You are required to select a main author, this author will receive the communications regarding your articles process through our systems. This does not have to be you." %}</p>
+                                <label for="main-author">{% trans "Select main author" %}:</label>
+                                <select class="form-control" id="main-author" name="main-author" required>
+                                    <option value="">---------</option>
+                                    {% for author in article.authors.all %}
+                                        <option value="{{ author.pk }}"
+                                                {% if article.correspondence_author.pk == author.pk %}selected{% endif %}>{{ author.full_name }}</option>
+                                    {% endfor %}
+                                </select>
+                                <br/>
                             </div>
                         </div>
                     </div>
@@ -228,59 +212,30 @@
                         <h2 id="section-four">4. Publication Info</h2>
                     </div>
                     <div class="content">
-                        <form method="POST">
-                            {% csrf_token %}
-                            <div class="large-4 columns">
-                                {{ pub_form.date_published|foundation }}
-                            </div>
-                            <div class="large-4 columns">
-                                {{ pub_form.date_accepted|foundation }}
-                            </div>
-                            <div class="large-4 columns">
-                                {{ pub_form.render_galley|foundation }}
-                            </div>
-                            <div class="large-4 columns">
-                                {{ pub_form.primary_issue|foundation }}
-                            </div>
-                            <div class="large-4 columns">
-                                {{ pub_form.page_numbers|foundation }}
-                            </div>
-                            <div class="large-4 columns">
-                                <br/>
-                                {{ pub_form.peer_reviewed|foundation }}
-                            </div>
-                            <div class="large-12 columns">
-                                {% if article and article.date_published %}
-                                <p>More Pub Info is available on the <a href="{% url 'publish_article' article.pk %}">Pre Publication Checklist</a>.</p>
-                                {% endif %}
-                            </div>
-                            <div class="large-12 columns">
-                                <button class="success button pull-right" type="submit" name="save_section_4"><i
-                                        class="fa fa-check">&nbsp;</i>{% trans "Save Section 4" %}</button>
-                            </div>
-                        </form>
-                    </div>
-                    <div class="title-area">
-                        <h2 id="section-five">5. Remote</h2>
-                    </div>
-                    <div class="content">
-                        <p>If your article is remote, you can fill the required details here. If the remote article has
-                            a DOI, you should use it for full resolution. .</p>
-                        <form method="POST">
-                            {% csrf_token %}
-                            <div class="row expanded">
-                                <div class="large-6 columns">
-                                    {{ remote_form.is_remote|foundation }}
-                                </div>
-                                <div class="large-6 columns">
-                                    {{ remote_form.remote_url|foundation }}
-                                </div>
-                                <div class="large-12 columns">
-                                    <button class="success button pull-right" type="submit" name="save_section_5"><i
-                                            class="fa fa-check">&nbsp;</i>{% trans "Save Section 5" %}</button>
-                                </div>
-                            </div>
-                        </form>
+                        <div class="large-4 columns">
+                            {{ pub_form.date_published|foundation }}
+                        </div>
+                        <div class="large-4 columns">
+                            {{ pub_form.date_accepted|foundation }}
+                        </div>
+                        <div class="large-4 columns">
+                            {{ pub_form.render_galley|foundation }}
+                        </div>
+                        <div class="large-4 columns">
+                            {{ pub_form.primary_issue|foundation }}
+                        </div>
+                        <div class="large-4 columns">
+                            {{ pub_form.page_numbers|foundation }}
+                        </div>
+                        <div class="large-4 columns">
+                            <br/>
+                            {{ pub_form.peer_reviewed|foundation }}
+                        </div>
+                        <div class="large-12 columns">
+                            {% if article and article.date_published %}
+                            <p>More Pub Info is available on the <a href="{% url 'publish_article' article.pk %}">Pre Publication Checklist</a>.</p>
+                            {% endif %}
+                        </div>
                     </div>
                     <div class="title-area">
                         <h2>6. Publish</h2>
@@ -289,12 +244,17 @@
                         <p>When you are ready to publish your article, press the publish button and it will be
                             published.</p>
                         <div class="large-12 columns">
-                            <form method="POST">
-                                {% csrf_token %}
-                                <button class="success button pull-right" type="submit" name="publish">
+                            <div class="button-group">
+                                <button class="success button" type="submit" name="save_add">
+                                    Save & Add Another
+                                </button>
+                                <button class="success button" type="submit" name="save_add">
+                                    Save & Close
+                                </button>
+                                <button class="success button" type="submit" name="publish">
                                     <i class="fa fa-check-circle">&nbsp;</i>Publish
                                 </button>
-                            </form>
+                            </div>
                         </div>
                     </div>
                     {% if article.date_published %}

--- a/templates/back_content/article_form.html
+++ b/templates/back_content/article_form.html
@@ -1,0 +1,109 @@
+{% extends "admin/core/base.html" %}
+{% load static %}
+
+{% block title %}Back Content Submission{% endblock %}
+
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="{% url 'bc_index' %}">Back Content Plugin</a></li>
+    <li>{% if article %}{{ article.safe_title }}{% else %}New Article{% endif %}</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+<section class="content">
+    <div class="row expanded">
+        <div class="large-12 columns box">
+            <form method="POST">
+                {% csrf_token %}
+                {% if deposit_form %}
+                <div class="title-area">
+                    <h2>Deposit Agreement</h2>
+                </div>
+                <div class="submission-content large-12 columns">
+                    {{ deposit_form }}
+                </div>
+                {% endif %}
+                <div class="title-area">
+                    <h2>Article Metadata</h2>
+                </div>
+                <div class="submission-content">
+                    <div class="large-12 columns">
+                        <label for="id_title">{% trans "Title" %}</label>
+                        {{ article_form.title }}
+                        {{ article_form.title.errors }}
+                    </div>
+                    {% if article_form.subtitle %}
+                    <div class="large-12 columns">
+                        <label for="id_subtitle">{% trans "Subtitle" %}</label>
+                        {{ article_form.subtitle }}
+                        {{ article_form.subtitle.errors }}
+                    </div>
+                    {% endif %}
+                    <div class="large-12 columns">
+                        <label for="id_abstract">
+                            {% trans "Abstract" %}{% if form.abstract.field.required %}*{% endif %}</label>
+                        {{ article_form.abstract }}
+                        {{ article_form.abstract.errors }}
+                    </div>
+                    <div class="large-4 columns">
+                        <label for="id_language">{% trans "Language" %}</label>
+                        {{ article_form.language }}
+                        {{ article_form.language.errors }}
+                    </div>
+                    <div class="large-4 columns">
+                        <label for="id_section">{% trans "Section" %}</label>
+                        {{ article_form.section }}
+                        {{ article_form.section.errors }}
+                    </div>
+                    <div class="large-4 columns error">
+                        <label for="id_license">{% if article_form.license.errors %}
+                            <span style="color: red;">{% endif %}{% trans "License" %}
+                            {% if article_form.license.errors %}</span>{% endif %}
+                            {% if article_form.license.field.required %}*{% endif %}</label>
+                        {{ article_form.license }}
+                        {{ article_form.license.errors }}
+                    </div>
+                    <div class="large-12 columns">
+                        <label for="id_keywords">Keywords</label>
+                        <input type="text" id="id_keywords" name="keywords" value="
+                                {% if article_form.cleaned_data.keywords %}
+                                    {{ article_form.cleaned_data.keywords }}
+                                {% else %}
+                                    {% for keyword in article.keywords.all %}
+                                        {{ keyword.word }}
+                                        {% if not forloop.last %},{% endif %}
+                                    {% endfor %}
+                                {% endif %}"/>
+                        Hit Enter to add a new keyword.
+                    </div>
+                </div>
+
+                {% include "admin/elements/submission/additional_fields.html" with form=article_form additional_fields=additional_fields %}
+
+                <div class="pull-right">
+                    <button class="success button" type="submit" name="save_close">
+                        <i class="fa fa-close">&nbsp;</i>Save & Close
+                    </button>
+                    <button class="success button" type="submit" name="save_continue">
+                        <i class="fa fa-arrow-right">&nbsp;</i>Save & Continue
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</section>
+{% endblock body %}
+
+{% block js %}
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
+    <script type="text/javascript" src="{% static "common/js/jq-ui.min.js" %}"></script>
+    <script src="{% static "common/js/tagit.js" %}"></script>
+
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $("#id_keywords").tagit(
+                {allowSpaces: true});
+        });
+    </script>
+{% endblock js %}

--- a/templates/back_content/author_form.html
+++ b/templates/back_content/author_form.html
@@ -1,7 +1,8 @@
 {% extends "admin/core/base.html" %}
 
-{% block title %}Back Content Submission - Add Authors{% endblock %}
+{% load static bool_fa securitytags %}
 
+{% block title %}Back Content Submission - Add Authors{% endblock %}
 
 {% block breadcrumbs %}
     {{ block.super }}
@@ -10,83 +11,99 @@
 {% endblock breadcrumbs %}
 
 {% block body %}
+{% can_see_pii_tag article as can_see_pii %}
 <section class="content">
     <div class="row expanded">
         <div class="large-12 columns box">
             <div class="title-area">
-                <h2>Article Authors</h2>
+                <h2 id="edit-metadata-authors">Article Authors</h2>
+                {% if frozen_author %}
+                    <a href="{% url 'edit_metadata' article.pk %}?modal=author&return={{ return }}" class="button">Add Author</a>
+                {% else %}
+                    <a href="#" class="button" data-open="author">Add Author</a>
+                {% endif %}
             </div>
-            <div class="content" data-equalizer data-equalize-on="medium">
-                <div class="large-7 columns" data-equalizer-watch>
-                    <p>{% trans "You can add an author by clicking the button below. This will open a popup modal for you to complete their details. If you do not have a legitimate email address for this author use @journal.com as a prefix for their email address and Janeway will ignore it." %}</p>
-                    <a href="#" data-open="author" class="small success button">{% trans "Add New Author" %}</a>
-                    {% include "admin/elements/submit/author.html" %}
-                    <p>{% trans "If you know of an existing author, you can search for them." %}</p>
-                    <a href="{% url 'bc_article_authors' article.pk %}" class="small success button">Search Accounts for Authors</a>
-                </div>
-                <div class="large-5 columns" data-equalizer-watch>
-                    <h4>{% trans "Current Authors" %}</h4>
-                    <div class="row">
-                        <form method="POST">
-                            {% csrf_token %}
-                            <table class="small scroll">
-                                <thead>
-                                <tr>
-                                    <th></th>
-                                    <th>{% trans "Name" %}</th>
-                                    <th>{% trans "Email" %}</th>
-                                    <th></th>
-                                    <th></th>
-                                </tr>
-                                </thead>
-                                <tbody id="sortable">
-                                {% for order in article.articleauthororder_set.all %}
-                                    <tr id="authors-{{ order.author.pk }}">
-                                        <td><i class="fa fa-sort"></i></td>
-                                        <td>{{ order.author.full_name }}</td>
-                                        <td>{{ order.author.email }}</td>
-                                        <td>
-                                            <button name="set_main" value="{{ order.author.pk }}" class="tiny button">Set as Main</button>
-                                        </td>
-                                        <td>
-                                            <button name="remove_author" value="{{ order.author.pk }}" class="tiny alert button">Remove</button>
-                                        </td>
-                                    </tr>
-                                    {% empty %}
-                                    <tr>
-                                        <td colspan="3">{% trans "No authors yet, add one!" %}</td>
-                                    </tr>
-                                {% endfor %}
-                            </table>
-                        </form>
-                        <hr/>
-                        <form method="POST">
-                            {% csrf_token %}
-                            <p>{% trans "You are required to select a main author, this author will receive the communications regarding your articles process through our systems. This does not have to be you." %}</p>
-                            <label for="main-author">{% trans "Select main author" %}:</label>
-                            <select class="form-control" id="main-author" name="main-author" required>
-                                <option value="">---------</option>
-                                {% for author in article.authors.all %}
-                                    <option value="{{ author.pk }}"
-                                            {% if article.correspondence_author.pk == author.pk %}selected{% endif %}>{{ author.full_name }}</option>
-                                {% endfor %}
-                            </select>
-                            <div class="pull-right">
-                                <button class="success button" type="submit" name="back">
-                                    <i class="fa fa-arrow-left">&nbsp;</i>Back
-                                </button>
-                                <button class="success button" type="submit" name="close">
-                                    <i class="fa fa-close">&nbsp;</i>Close
-                                </button>
-                                <button class="success button" type="submit" name="continue">
-                                    <i class="fa fa-arrow-right">&nbsp;</i>Continue
-                                </button>
-                            </div>
-                        </form>
+            <div class="submission-content">
+                <form method="POST">
+                    {% csrf_token %}
+                    <table class="small scroll">
+                        <thead>
+                        <tr>
+                            <th></th>
+                            <th>Name</th>
+                            <th>Email</th>
+                            <th>Display Email Link?</th>
+                            <th>Institution</th>
+                            <th>Edit</th>
+                            <th>Delete</th>
+                        </tr>
+                        </thead>
+                        <tbody id="sortable">
+                        {% for f_author in article.frozen_authors %}
+                            <tr id="authors-{{ f_author.pk }}">
+                                <td><i class="fa fa-sort"></i></td>
+                                <td>{{ f_author.full_name|se_can_see_pii:article }}</td>
+                                <td>{{ f_author.email|se_can_see_pii:article }}</td>
+                                <td>{{ f_author.display_email|bool_fa }}</td>
+                                <td>{{ f_author.institution|se_can_see_pii:article }}</td>
+                                <td>{% if can_see_pii %}
+                                <a href="?author={{ f_author.pk }}&return={{ return }}"><i
+                                        class="fa fa-edit">&nbsp;</i>Edit</a>
+                                {% else %}
+                                    Author data cannot be edited
+                                {% endif %}
+                                </td>
+                                <td>
+                                    <form method="POST">
+                                        {% csrf_token %}
+                                        <button type="submit" name="delete" value="{{ f_author.pk }}"><i
+                                                class="fa fa-trash">&nbsp;</i>Delete
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                    <div class="pull-right">
+                        <button class="success button" type="submit" name="back">
+                            <i class="fa fa-arrow-left">&nbsp;</i>Back
+                        </button>
+                        <button class="success button" type="submit" name="close">
+                            <i class="fa fa-close">&nbsp;</i>Save & Close
+                        </button>
+                        <button class="success button" type="submit" name="continue">
+                            <i class="fa fa-arrow-right">&nbsp;</i>Save & Continue
+                        </button>
                     </div>
-                </div>
+                </form>
             </div>
         </div>
     </div>
 </section>
+{% include "admin/elements/submission/edit_author.html" %}
 {% endblock body %}
+
+{% block js %}
+    {% if modal %}
+        {% include "admin/elements/open_modal.html" with target=modal %}
+    {% endif %}
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
+    <script type="text/javascript" src="{% static "common/js/jq-ui.min.js" %}"></script>
+    <script>
+        $( "#sortable" ).sortable({
+            update: function (event, ui) {
+                var data = $(this).sortable('serialize');
+                console.log(data);
+                // POST to server using $.post or $.ajax
+                $.ajax({
+                    data: data,
+                    type: 'POST',
+                    url: '{% url 'order_authors' article.pk %}'
+                });
+            }
+        });
+        $( "#sortable" ).disableSelection();
+    </script>
+{% endblock js %}
+

--- a/templates/back_content/author_form.html
+++ b/templates/back_content/author_form.html
@@ -90,6 +90,7 @@
     {% endif %}
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
     <script type="text/javascript" src="{% static "common/js/jq-ui.min.js" %}"></script>
+    <script src="{% static "admin/js/csrf.js" %}"></script>
     <script>
         $( "#sortable" ).sortable({
             update: function (event, ui) {

--- a/templates/back_content/author_form.html
+++ b/templates/back_content/author_form.html
@@ -1,0 +1,92 @@
+{% extends "admin/core/base.html" %}
+
+{% block title %}Back Content Submission - Add Authors{% endblock %}
+
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="{% url 'bc_index' %}">Back Content Plugin</a></li>
+    <li>{{ article.safe_title }}</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+<section class="content">
+    <div class="row expanded">
+        <div class="large-12 columns box">
+            <div class="title-area">
+                <h2>Article Authors</h2>
+            </div>
+            <div class="content" data-equalizer data-equalize-on="medium">
+                <div class="large-7 columns" data-equalizer-watch>
+                    <p>{% trans "You can add an author by clicking the button below. This will open a popup modal for you to complete their details. If you do not have a legitimate email address for this author use @journal.com as a prefix for their email address and Janeway will ignore it." %}</p>
+                    <a href="#" data-open="author" class="small success button">{% trans "Add New Author" %}</a>
+                    {% include "admin/elements/submit/author.html" %}
+                    <p>{% trans "If you know of an existing author, you can search for them." %}</p>
+                    <a href="{% url 'bc_article_authors' article.pk %}" class="small success button">Search Accounts for Authors</a>
+                </div>
+                <div class="large-5 columns" data-equalizer-watch>
+                    <h4>{% trans "Current Authors" %}</h4>
+                    <div class="row">
+                        <form method="POST">
+                            {% csrf_token %}
+                            <table class="small scroll">
+                                <thead>
+                                <tr>
+                                    <th></th>
+                                    <th>{% trans "Name" %}</th>
+                                    <th>{% trans "Email" %}</th>
+                                    <th></th>
+                                    <th></th>
+                                </tr>
+                                </thead>
+                                <tbody id="sortable">
+                                {% for order in article.articleauthororder_set.all %}
+                                    <tr id="authors-{{ order.author.pk }}">
+                                        <td><i class="fa fa-sort"></i></td>
+                                        <td>{{ order.author.full_name }}</td>
+                                        <td>{{ order.author.email }}</td>
+                                        <td>
+                                            <button name="set_main" value="{{ order.author.pk }}" class="tiny button">Set as Main</button>
+                                        </td>
+                                        <td>
+                                            <button name="remove_author" value="{{ order.author.pk }}" class="tiny alert button">Remove</button>
+                                        </td>
+                                    </tr>
+                                    {% empty %}
+                                    <tr>
+                                        <td colspan="3">{% trans "No authors yet, add one!" %}</td>
+                                    </tr>
+                                {% endfor %}
+                            </table>
+                        </form>
+                        <hr/>
+                        <form method="POST">
+                            {% csrf_token %}
+                            <p>{% trans "You are required to select a main author, this author will receive the communications regarding your articles process through our systems. This does not have to be you." %}</p>
+                            <label for="main-author">{% trans "Select main author" %}:</label>
+                            <select class="form-control" id="main-author" name="main-author" required>
+                                <option value="">---------</option>
+                                {% for author in article.authors.all %}
+                                    <option value="{{ author.pk }}"
+                                            {% if article.correspondence_author.pk == author.pk %}selected{% endif %}>{{ author.full_name }}</option>
+                                {% endfor %}
+                            </select>
+                            <div class="pull-right">
+                                <button class="success button" type="submit" name="back">
+                                    <i class="fa fa-arrow-left">&nbsp;</i>Back
+                                </button>
+                                <button class="success button" type="submit" name="close">
+                                    <i class="fa fa-close">&nbsp;</i>Close
+                                </button>
+                                <button class="success button" type="submit" name="continue">
+                                    <i class="fa fa-arrow-right">&nbsp;</i>Continue
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock body %}

--- a/templates/back_content/author_search.html
+++ b/templates/back_content/author_search.html
@@ -7,8 +7,8 @@
 {% block breadcrumbs %}
   {{ block.super }}
     <li><a href="{% url 'bc_index' %}">Back Content Plugin</a></li>
-    <li><a href="{% url 'bc_article' article.pk %}">{{ article.safe_title }}</a></li>
-    <li>Add Authors</li>
+    <li><a href="{% url 'bc_add_authors' article.pk %}">{{ article.safe_title }}</a></li>
+    <li>Search Authors</li>
 {% endblock %}
 
 {% block title %}Search for Authors | {{ block.super }}{% endblock %}
@@ -28,7 +28,7 @@
             you can return to the main article page.
           </p>
           <p>
-            <a href="{% url 'bc_article' article.pk %}#section-two" class="small success button">
+            <a href="{% url 'bc_add_authors' article.pk %}" class="small success button">
               Return to Main Article Page
             </a>
           </p>

--- a/templates/back_content/edit_article_form.html
+++ b/templates/back_content/edit_article_form.html
@@ -1,0 +1,75 @@
+{% extends "admin/core/base.html" %}
+
+{% block title %}Back Content Submission{% endblock %}
+
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="{% url 'bc_index' %}">Back Content Plugin</a></li>
+    <li>{% if article %}{{ article.safe_title }}{% else %}New Article{% endif %}</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+<section class="content">
+    <div class="row expanded">
+        <div class="large-12 columns box">
+            <form method="POST">
+                {% csrf_token %}
+                <div class="title-area">
+                    <h2 id="section-one">1. Article Metadata</h2>
+                </div>
+                <div class="content">
+                    <div class="large-12 columns">
+                        <label for="id_title">{% trans "Title" %}</label>
+                        {{ article_form.title }}
+                        {{ article_form.title.errors }}
+                    </div>
+                    <div class="large-12 columns">
+                        <label for="id_abstract">
+                            {% trans "Abstract" %}{% if form.abstract.field.required %}*{% endif %}</label>
+                        {{ article_form.abstract }}
+                        {{ article_form.abstract.errors }}
+                    </div>
+                    <div class="large-4 columns">
+                        <label for="id_language">{% trans "Language" %}</label>
+                        {{ article_form.language }}
+                        {{ article_form.language.errors }}
+                    </div>
+                    <div class="large-4 columns">
+                        <label for="id_section">{% trans "Section" %}</label>
+                        {{ article_form.section }}
+                        {{ article_form.section.errors }}
+                    </div>
+                    <div class="large-4 columns error">
+                        <label for="id_license">{% if article_form.license.errors %}
+                            <span style="color: red;">{% endif %}{% trans "License" %}
+                            {% if article_form.license.errors %}</span>{% endif %}
+                            {% if article_form.license.field.required %}*{% endif %}</label>
+                        {{ article_form.license }}
+                        {{ article_form.license.errors }}
+                    </div>
+                    <div class="large-12 columns">
+                        <label for="id_keywords">Keywords</label>
+                        <input type="text" id="id_keywords" name="keywords" value="
+                                {% if article_form.cleaned_data.keywords %}{{ article_form.cleaned_data.keywords }}{% else %}{% for keyword in article.keywords.all %}{{ keyword.word }}{% if not forloop.last %},{% endif %}{% endfor %}{% endif %}"/>
+                        Hit Enter to add a new keyword.
+                    </div>
+
+                    {% include "admin/elements/submission/additional_fields.html" with form=article_form additional_fields=additional_fields %}
+                </div>
+                <div class="large-12 columns">
+                    <div class="button-group">
+                        <button class="success button" type="submit" name="save_close">
+                            Save & Close
+                        </button>
+                        <button class="success button" type="submit" name="save_continue">
+                            Save & Continue
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</section>
+{% endblock body %}
+

--- a/templates/back_content/elements/file_table.html
+++ b/templates/back_content/elements/file_table.html
@@ -1,0 +1,55 @@
+{% load files %}
+
+<table id="files" class="small files">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Label</th>
+        <th>Filename</th>
+        <th>Type</th>
+        {% if is_galley %}<th>Public</th>{% endif %}
+        <th>Uploaded</th>
+        <th>Modified</th>
+        <th>Download</th>
+        <th>History</th>
+        <th>Replace</th>
+        <th>Delete</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for i in items %}
+        {% can_edit_file file article as can_edit_file_flag %}
+        {% can_view_file file as can_view_file_flag %}
+        {% can_view_file_history file article as can_view_file_history_flag %}
+        <tr>
+            <td>{{ file.pk }}</td>
+            <td class="wrap-long-text">{% if not file.label %}No Label{% endif %}{{ file.label }}</td>
+            <td class="wrap-long-text">{{ file }}</td>
+            <td>{% file_type article file %}</td>
+            {% if is_galley %}<td>{{ i.public|bool_fa }}</td>{% endif %}
+            <td>{{ file.date_uploaded|date:"Y-m-d G:i" }}</td>
+            <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
+            <td>{% if can_view_file_flag %}
+                <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
+                        class="fa fa-download">
+                    &nbsp;</i></a>{% endif %}</td>
+            <td>{% if can_view_file_history_flag %}
+                <a href="{% url 'file_history' article.pk file.pk %}?return={{ request.path|urlencode }}"><i
+                        class="fa fa-history">
+                    &nbsp;</i></a>{% endif %}
+            </td>
+            <td>{% if can_edit_file_flag %}
+                <a href="{% url 'article_file_replace' 'id' article.pk file.pk %}?return={{ request.path|urlencode }}%3Freturn%3D{{ request.GET.return|urlencode }}"><i
+                        class="fa fa-cloud-upload">&nbsp;</i></a>{% endif %}</td>
+            <td>{% if can_edit_file_flag %}
+                <a href="{% url 'file_delete' article.pk file.pk %}?return={{ request.path|urlencode }}%3Freturn%3D{{ request.GET.return|urlencode }}"><i
+                        class="fa fa-trash">
+                    &nbsp;</i></a>{% endif %}</td>
+        </tr>
+    {% empty %}
+        <tr>
+            <td colspan="9">No files have been uploaded.</td>
+        </tr>
+    {% endfor %}
+</tbody>
+</table>

--- a/templates/back_content/galley_form.html
+++ b/templates/back_content/galley_form.html
@@ -150,10 +150,10 @@
                         <i class="fa fa-arrow-left">&nbsp;</i>Back
                     </button>
                     <button class="success button" type="submit" name="close">
-                        <i class="fa fa-close">&nbsp;</i>Close
+                        <i class="fa fa-close">&nbsp;</i>Save & Close
                     </button>
                     <button class="success button" type="submit" name="continue">
-                        <i class="fa fa-arrow-right">&nbsp;</i>Continue
+                        <i class="fa fa-arrow-right">&nbsp;</i>Save & Continue
                     </button>
                 </div>
             </form>

--- a/templates/back_content/galley_form.html
+++ b/templates/back_content/galley_form.html
@@ -1,0 +1,112 @@
+{% extends "admin/core/base.html" %}
+
+{% load bool_fa %}
+{% load files %}
+
+{% block title %}Back Content Submission - Add Galleys{% endblock %}
+
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="{% url 'bc_index' %}">Back Content Plugin</a></li>
+    <li>{{ article.safe_title }}</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+<section class="content">
+    <div class="row expanded">
+        <div class="large-12 columns box">
+            <form method="POST">
+                {% csrf_token %}
+               <div class="title-area">
+                    <h2 id="section-three">3. Galleys</h2>
+                </div>
+                <div class="content">
+                    <p>
+                    <table class="table table-bordered table-condensed small">
+                        <tr style="text-align: left">
+                            <th>Label</th>
+                            <th width="25%">Filename</th>
+                            <th>Public</th>
+                            <th>Type</th>
+                            <th>Edit</th>
+                            <th>Download</th>
+                            <th>Replace</th>
+                            <th>History</th>
+                            <th>Create PDF</th>
+                        </tr>
+                        {% for galley in galleys %}
+                            {% can_view_file galley.file as can_view_file_flag %}
+                            {% can_edit_file galley.file article as can_edit_file_flag %}
+                            {% can_view_file_history galley.file article as can_view_file_history_flag %}
+                            <tr>
+                                <td>{{ galley.label }}</td>
+                                <td>{{ galley.file.original_filename|truncatechars:40 }} {% if galley.label == 'XML' %}
+                                    &nbsp;
+                                    <small><a target="_blank"
+                                              href="{% url 'bc_preview_xml_galley' article.pk galley.pk %}"><i
+                                            class="fa fa-search" aria-hidden="true">&nbsp;</i>Preview</a>
+                                    </small>{% endif %}</td>
+                                <td>{{ galley.public|bool_fa }}</td>
+                                <td>Galley</td>
+                                <td><a href="{% url 'pm_edit_galley' article.pk galley.pk %}" class="fa fa-edit"></a>
+                                </td>
+                                <td>{% if can_view_file_flag %}
+                                    <a href="{% url 'article_file_download' 'id' article.pk galley.file.pk %}"><i
+                                            class="fa fa-download">&nbsp;</i></a>{% endif %}
+                                </td>
+                                <td>{% if can_edit_file_flag %}
+                                    <a href="{% url 'article_file_replace' 'id' article.pk galley.file.pk %}?return={{ request.path|urlencode }}"><i
+                                            class="fa fa-cloud-upload">&nbsp;</i></a>{% endif %}
+                                </td>
+                                <td>{% if can_view_file_history_flag %}
+                                    <a href="{% url 'file_history' article.pk galley.file.pk %}?return={{ request.path|urlencode }}"><i
+                                            class="fa fa-history">
+                                        &nbsp;</i></a>{% endif %}
+                                </td>
+                                <td>
+                                    {% if galley.file.mime_type == 'application/xml' and not galley.has_missing_image_files %}
+                                        <a href="{% url 'cassius_generate' galley.pk %}?return={{ request.path|urlencode }}">
+                                            <i class="fa fa-file-text-o">&nbsp;</i>
+                                        </a>
+                                    {% elif not galley.file.mime_type == 'application/xml' %}
+                                        Function for XML only.
+                                    {% elif galley.file.mime_type == 'application/xml' and galley.has_missing_image_files %}
+                                        <p><span data-tooltip aria-haspopup="true" class="has-tip top"
+                                                 data-disable-hover="false"
+                                                 tabindex="2"
+                                                 title="{% has_missing_supplements galley %}">Missing Supplements</span>
+                                        </p>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% empty %}
+                            <tr>
+                                <td colspan="9">No galleys have been uploaded.</td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                    <a class="button success float-right" data-open="uploadbox">
+                        <i class="fa fa-cloud-upload">&nbsp;</i>
+                        Upload a new galley
+                    </a>
+                    </p>
+                    <hr>
+                    <div class="pull-right">
+                        <button class="success button" type="submit" name="back">
+                            <i class="fa fa-arrow-left">&nbsp;</i>Back
+                        </button>
+                        <button class="success button" type="submit" name="close">
+                            <i class="fa fa-close">&nbsp;</i>Close
+                        </button>
+                        <button class="success button" type="submit" name="continue">
+                            <i class="fa fa-arrow-right">&nbsp;</i>Continue
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</section>
+{% include "elements/production/new_galley.html" %}
+{% endblock body %}

--- a/templates/back_content/galley_form.html
+++ b/templates/back_content/galley_form.html
@@ -18,95 +18,148 @@
         <div class="large-12 columns box">
             <form method="POST">
                 {% csrf_token %}
-               <div class="title-area">
-                    <h2 id="section-three">3. Galleys</h2>
+                <div class="title-area">
+                    <h2>Galleys</h2>
                 </div>
-                <div class="content">
-                    <p>
-                    <table class="table table-bordered table-condensed small">
-                        <tr style="text-align: left">
+                <div class="submission-content">
+                    <table id="files" class="small files">
+                        <thead>
+                        <tr>
+                            <th>ID</th>
                             <th>Label</th>
-                            <th width="25%">Filename</th>
-                            <th>Public</th>
+                            <th>Filename</th>
                             <th>Type</th>
-                            <th>Edit</th>
+                            <th>Public</th>
+                            <th>Uploaded</th>
+                            <th>Modified</th>
                             <th>Download</th>
-                            <th>Replace</th>
                             <th>History</th>
-                            <th>Create PDF</th>
+                            <th>Replace</th>
+                            <th>Delete</th>
                         </tr>
+                        </thead>
+                        <tbody>
                         {% for galley in galleys %}
-                            {% can_view_file galley.file as can_view_file_flag %}
-                            {% can_edit_file galley.file article as can_edit_file_flag %}
-                            {% can_view_file_history galley.file article as can_view_file_history_flag %}
+                            {% with file=galley.file %}
+                                {% can_edit_file file article as can_edit_file_flag %}
+                                {% can_view_file file as can_view_file_flag %}
+                                {% can_view_file_history file article as can_view_file_history_flag %}
+                                <tr>
+                                    <td>{{ file.pk }}</td>
+                                    <td class="wrap-long-text">{% if not file.label %}No Label{% endif %}{{ file.label }}</td>
+                                    <td class="wrap-long-text">{{ file }}</td>
+                                    <td>{% file_type article file %}</td>
+                                    <td>{{ galley.public|bool_fa }}</td>
+                                    <td>{{ file.date_uploaded|date:"Y-m-d G:i" }}</td>
+                                    <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
+                                    <td>{% if can_view_file_flag %}
+                                        <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
+                                                class="fa fa-download">
+                                            &nbsp;</i></a>{% endif %}</td>
+                                    <td>{% if can_view_file_history_flag %}
+                                        <a href="{% url 'file_history' article.pk file.pk %}?return={{ request.path|urlencode }}"><i
+                                                class="fa fa-history">
+                                            &nbsp;</i></a>{% endif %}
+                                    </td>
+                                    <td>{% if can_edit_file_flag %}
+                                        <a href="{% url 'article_file_replace' 'id' article.pk file.pk %}?return={{ request.path|urlencode }}%3Freturn%3D{{ request.GET.return|urlencode }}"><i
+                                                class="fa fa-cloud-upload">&nbsp;</i></a>{% endif %}</td>
+                                    <td>{% if can_edit_file_flag %}
+                                        <a href="{% url 'file_delete' article.pk file.pk %}?return={{ request.path|urlencode }}%3Freturn%3D{{ request.GET.return|urlencode }}"><i
+                                                class="fa fa-trash">
+                                            &nbsp;</i></a>{% endif %}</td>
+                                </tr>
+                            {% endwith %}
+                        {% empty %}
                             <tr>
-                                <td>{{ galley.label }}</td>
-                                <td>{{ galley.file.original_filename|truncatechars:40 }} {% if galley.label == 'XML' %}
-                                    &nbsp;
-                                    <small><a target="_blank"
-                                              href="{% url 'bc_preview_xml_galley' article.pk galley.pk %}"><i
-                                            class="fa fa-search" aria-hidden="true">&nbsp;</i>Preview</a>
-                                    </small>{% endif %}</td>
-                                <td>{{ galley.public|bool_fa }}</td>
-                                <td>Galley</td>
-                                <td><a href="{% url 'pm_edit_galley' article.pk galley.pk %}" class="fa fa-edit"></a>
-                                </td>
-                                <td>{% if can_view_file_flag %}
-                                    <a href="{% url 'article_file_download' 'id' article.pk galley.file.pk %}"><i
-                                            class="fa fa-download">&nbsp;</i></a>{% endif %}
-                                </td>
-                                <td>{% if can_edit_file_flag %}
-                                    <a href="{% url 'article_file_replace' 'id' article.pk galley.file.pk %}?return={{ request.path|urlencode }}"><i
-                                            class="fa fa-cloud-upload">&nbsp;</i></a>{% endif %}
-                                </td>
-                                <td>{% if can_view_file_history_flag %}
-                                    <a href="{% url 'file_history' article.pk galley.file.pk %}?return={{ request.path|urlencode }}"><i
-                                            class="fa fa-history">
-                                        &nbsp;</i></a>{% endif %}
-                                </td>
-                                <td>
-                                    {% if galley.file.mime_type == 'application/xml' and not galley.has_missing_image_files %}
-                                        <a href="{% url 'cassius_generate' galley.pk %}?return={{ request.path|urlencode }}">
-                                            <i class="fa fa-file-text-o">&nbsp;</i>
-                                        </a>
-                                    {% elif not galley.file.mime_type == 'application/xml' %}
-                                        Function for XML only.
-                                    {% elif galley.file.mime_type == 'application/xml' and galley.has_missing_image_files %}
-                                        <p><span data-tooltip aria-haspopup="true" class="has-tip top"
-                                                 data-disable-hover="false"
-                                                 tabindex="2"
-                                                 title="{% has_missing_supplements galley %}">Missing Supplements</span>
-                                        </p>
-                                    {% endif %}
-                                </td>
-                            </tr>
-                            {% empty %}
-                            <tr>
-                                <td colspan="9">No galleys have been uploaded.</td>
+                                <td colspan="9">No files have been uploaded.</td>
                             </tr>
                         {% endfor %}
+                    </tbody>
                     </table>
                     <a class="button success float-right" data-open="uploadbox">
                         <i class="fa fa-cloud-upload">&nbsp;</i>
                         Upload a new galley
                     </a>
-                    </p>
-                    <hr>
-                    <div class="pull-right">
-                        <button class="success button" type="submit" name="back">
-                            <i class="fa fa-arrow-left">&nbsp;</i>Back
-                        </button>
-                        <button class="success button" type="submit" name="close">
-                            <i class="fa fa-close">&nbsp;</i>Close
-                        </button>
-                        <button class="success button" type="submit" name="continue">
-                            <i class="fa fa-arrow-right">&nbsp;</i>Continue
-                        </button>
-                    </div>
+                </div>
+                <div class="title-area">
+                    <h2>Supplementary Files</h2>
+                </div>
+                <div class="submission-content">
+                    <table id="files" class="small files">
+                        <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Label</th>
+                            <th>Filename</th>
+                            <th>Type</th>
+                            <th>Uploaded</th>
+                            <th>Modified</th>
+                            <th>Download</th>
+                            <th>History</th>
+                            <th>Replace</th>
+                            <th>Delete</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for s in article.supplementary_files.all %}
+                            {% with file=s.file %}
+                                {% can_edit_file file article as can_edit_file_flag %}
+                                {% can_view_file file as can_view_file_flag %}
+                                {% can_view_file_history file article as can_view_file_history_flag %}
+                                <tr>
+                                    <td>{{ file.pk }}</td>
+                                    <td class="wrap-long-text">{% if not file.label %}No Label{% endif %}{{ file.label }}</td>
+                                    <td class="wrap-long-text">{{ file }}</td>
+                                    <td>{% file_type article file %}</td>
+                                    <td>{{ file.date_uploaded|date:"Y-m-d G:i" }}</td>
+                                    <td>{{ file.last_modified|date:"Y-m-d G:i" }}</td>
+                                    <td>{% if can_view_file_flag %}
+                                        <a href="{% url 'article_file_download' 'id' article.pk file.pk %}"><i
+                                                class="fa fa-download">
+                                            &nbsp;</i></a>{% endif %}</td>
+                                    <td>{% if can_view_file_history_flag %}
+                                        <a href="{% url 'file_history' article.pk file.pk %}?return={{ request.path|urlencode }}"><i
+                                                class="fa fa-history">
+                                            &nbsp;</i></a>{% endif %}
+                                    </td>
+                                    <td>{% if can_edit_file_flag %}
+                                        <a href="{% url 'article_file_replace' 'id' article.pk file.pk %}?return={{ request.path|urlencode }}%3Freturn%3D{{ request.GET.return|urlencode }}"><i
+                                                class="fa fa-cloud-upload">&nbsp;</i></a>{% endif %}</td>
+                                    <td>{% if can_edit_file_flag %}
+                                        <a href="{% url 'file_delete' article.pk file.pk %}?return={{ request.path|urlencode }}%3Freturn%3D{{ request.GET.return|urlencode }}"><i
+                                                class="fa fa-trash">
+                                            &nbsp;</i></a>{% endif %}</td>
+                                </tr>
+                            {% endwith %}
+                        {% empty %}
+                            <tr>
+                                <td colspan="9">No files have been uploaded.</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                    </table>
+                    <a class="button success float-right" data-open="suppfile">
+                        <i class="fa fa-cloud-upload">&nbsp;</i>
+                        Upload a new supplementary file
+                    </a>
+                </div>
+                <hr>
+                <div class="pull-right">
+                    <button class="success button" type="submit" name="back">
+                        <i class="fa fa-arrow-left">&nbsp;</i>Back
+                    </button>
+                    <button class="success button" type="submit" name="close">
+                        <i class="fa fa-close">&nbsp;</i>Close
+                    </button>
+                    <button class="success button" type="submit" name="continue">
+                        <i class="fa fa-arrow-right">&nbsp;</i>Continue
+                    </button>
                 </div>
             </form>
         </div>
     </div>
 </section>
 {% include "elements/production/new_galley.html" %}
+{% include "elements/production/new_supp_file.html" %}
 {% endblock body %}

--- a/templates/back_content/index.html
+++ b/templates/back_content/index.html
@@ -1,0 +1,66 @@
+{% extends "admin/core/base.html" %}
+{% load foundation %}
+{% load static %}
+{% load securitytags %}
+{% load files %}
+{% load i18n %}
+
+{% block title %}Back Content Submission{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="{% url 'bc_index' %}">Back Content Plugin</a></li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+    <section class="content">
+        <div class="row expanded">
+            <div class="box">
+                <div class="title-area">
+                    <h2>New Article</h2>
+                </div>
+                <div class="content">
+                    <p>To submit an article, click the start button below. You can import data from a DOI or URL below. JATS XML import is now handled in the Imports plugin.</p>
+                        <a href="{% url 'bc_create_article' %}" class="success button"><i class="fa fa-upload">&nbsp;</i>Start Submission</a>
+                        <a href="{% url 'bc_doi_import' %}" class="success button"><i class="fa fa-upload">&nbsp;</i>Import Metadata from DOI or URL</a>
+                    </form>
+                </div>
+                <div class="title-area">
+                    <h2>In Progress Articles</h2>
+                </div>
+                <div class="content">
+                    <table class="table table-bordered small" id="bcplugin">
+                        <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Title</th>
+                            <th>Submitted</th>
+                            <th>Main Author</th>
+                            <th>Section</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for article in articles %}
+                            <tr>
+                                <td>{{ article.pk }}</td>
+                                <td><a href="{% url 'bc_edit_article' article.pk %}">{{ article.safe_title }}</a></td>
+                                <td>{{ article.date_submitted }}</td>
+                                <td>{{ article.correspondence_author.full_name }}</td>
+                                <td>{{ article.section.name }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr>
+                                <td colspan="5">No articles in this stage</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+{% block js %}
+    {% include "elements/datatables.html" with target="#bcplugin" %}
+{% endblock js %}

--- a/templates/back_content/index.html
+++ b/templates/back_content/index.html
@@ -21,9 +21,9 @@
                 </div>
                 <div class="content">
                     <p>To submit an article, click the start button below. You can import data from a DOI or URL below. JATS XML import is now handled in the Imports plugin.</p>
-                        <a href="{% url 'bc_create_article' %}" class="success button"><i class="fa fa-upload">&nbsp;</i>Start Submission</a>
-                        <a href="{% url 'bc_doi_import' %}" class="success button"><i class="fa fa-upload">&nbsp;</i>Import Metadata from DOI or URL</a>
-                    </form>
+                    <p>Complete and Published articles can be viewed in their assigned issue.</p>
+                    <a href="{% url 'bc_create_article' %}" class="success button"><i class="fa fa-upload">&nbsp;</i>Start Submission</a>
+                    <a href="{% url 'bc_doi_import' %}" class="success button"><i class="fa fa-upload">&nbsp;</i>Import Metadata from DOI or URL</a>
                 </div>
                 <div class="title-area">
                     <h2>In Progress Articles</h2>

--- a/templates/back_content/publish_form.html
+++ b/templates/back_content/publish_form.html
@@ -45,6 +45,9 @@
                 </div>
                 <div class="large-12 columns">
                     <div class="pull-right">
+                        <button class="success button" type="submit" name="back">
+                            <i class="fa fa-arrow-left">&nbsp;</i>Back
+                        </button>
                         <button class="success button" type="submit" name="save_another">
                             Save & Add Another
                         </button>

--- a/templates/back_content/publish_form.html
+++ b/templates/back_content/publish_form.html
@@ -1,0 +1,64 @@
+{% extends "admin/core/base.html" %}
+{% load foundation %}
+
+{% block title %}Back Content Submission - Publish{% endblock %}
+
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li><a href="{% url 'bc_index' %}">Back Content Plugin</a></li>
+    <li>{{ article.safe_title }}</li>
+{% endblock breadcrumbs %}
+
+{% block body %}
+<section class="content">
+    <div class="row expanded">
+        <div class="large-12 columns box">
+            <form method="POST">
+                {% csrf_token %}
+                <div class="title-area">
+                    <h2 id="section-four">4. Publication Info</h2>
+                </div>
+                <div class="large-4 columns">
+                    {{ pub_form.date_published|foundation }}
+                </div>
+                <div class="large-4 columns">
+                    {{ pub_form.date_accepted|foundation }}
+                </div>
+                <div class="large-4 columns">
+                    {{ pub_form.render_galley|foundation }}
+                </div>
+                <div class="large-4 columns">
+                    {{ pub_form.primary_issue|foundation }}
+                </div>
+                <div class="large-4 columns">
+                    {{ pub_form.page_numbers|foundation }}
+                </div>
+                <div class="large-4 columns">
+                    <br/>
+                    {{ pub_form.peer_reviewed|foundation }}
+                </div>
+                <div class="large-12 columns">
+                    {% if article and article.date_published %}
+                    <p>More Pub Info is available on the <a href="{% url 'publish_article' article.pk %}">Pre Publication Checklist</a>.</p>
+                    {% endif %}
+                </div>
+                <div class="large-12 columns">
+                    <div class="pull-right">
+                        <button class="success button" type="submit" name="save_another">
+                            Save & Add Another
+                        </button>
+                        <button class="success button" type="submit" name="save_close">
+                            Save & Close
+                        </button>
+                        <button class="success button" type="submit" name="publish">
+                            <i class="fa fa-check">&nbsp;</i>
+                            {% trans "Publish" %}
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</section>
+{% endblock body %}

--- a/urls.py
+++ b/urls.py
@@ -6,7 +6,11 @@ from journal.views import article_figure
 
 urlpatterns = [
     re_path(r'^$', views.index, name='bc_index'),
-    re_path(r'^article/(?P<article_id>\d+)/$', views.article, name='bc_article'),
+    re_path(r'^article/create/$', views.create_article, name='bc_create_article'),
+    re_path(r'^article/(?P<article_id>\d+)/edit/$', views.edit_article, name='bc_edit_article'),
+    re_path(r'^article/(?P<article_id>\d+)/authors/$', views.add_authors, name='bc_add_authors'),
+    re_path(r'^article/(?P<article_id>\d+)/galleys/$', views.add_galleys, name='bc_add_galleys'),
+    re_path(r'^article/(?P<article_id>\d+)/publish/$', views.publish, name='bc_publish_article'),
 
     re_path(r'^doi_import/$', views.doi_import, name='bc_doi_import'),
 
@@ -18,7 +22,7 @@ urlpatterns = [
         name='bc_article_figure',
     ),
     re_path(
-        r'^article/(?P<article_id>\d+)/authors/$',
+        r'^article/(?P<article_id>\d+)/add_author/$',
         views.BCPAuthorSearch.as_view(),
         name='bc_article_authors',
     ),

--- a/views.py
+++ b/views.py
@@ -7,149 +7,132 @@ from django.utils import timezone
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 
-from submission import models, forms, logic
-from core import models as core_models, files
-from plugins.back_content import forms as bc_forms, logic as bc_logic, plugin_settings
-from production import logic as prod_logic, forms as prod_forms
-from identifiers import logic as id_logic
+from submission.forms import AuthorForm
+from plugins.back_content.forms import (ArticleInfo,
+                                        PublicationInfo,
+                                        DepositAgreementForm,
+                                        RemoteParse)
+from submission.models import (Article,
+                               ArticleAuthorOrder,
+                               STAGE_PUBLISHED)
 from security.decorators import editor_user_required
-from utils import shared
-from journal import logic as journal_logic
-from events import logic as event_logic
 
+from submission.logic import check_author_exists
+from core.models import Account, Galley
+from utils.shared import generate_password
+from core.views import BaseUserList
+
+from production.logic import (save_galley,
+                              get_all_galleys,
+                              get_and_parse_doi_metadata,
+                              parse_url_results)
+from production.forms import GalleyForm
+from journal.logic import get_galley_content
 
 @editor_user_required
 def index(request):
-    if request.POST:
-        article = models.Article.objects.create(
-            journal=request.journal,
-            date_accepted=timezone.now(),
-            is_import=True,
-            article_agreement='This record was created using the back '
-                              'content plugin.',
-        )
-        return redirect(reverse('bc_article', kwargs={'article_id': article.pk}))
-
-    articles = models.Article.objects.filter(
+    articles = Article.objects.filter(
         journal=request.journal,
+    ).exclude(
+        stage=STAGE_PUBLISHED
     ).select_related(
         'correspondence_author',
         'section',
     )
 
-    template = 'back_content/new_article.html'
+    template = 'back_content/index.html'
     context = {
         'articles': articles,
     }
 
     return render(request, template, context)
 
+@editor_user_required
+def create_article(request):
+    additional_fields = request.journal.field_set.all()
+    if request.method == 'POST':
+        article_form = ArticleInfo(request.POST,
+                                   additional_fields=additional_fields,
+                                   journal=request.journal)
+        deposit_form = DepositAgreementForm(request.POST)
+        if article_form.is_valid() and deposit_form.is_valid():
+            article = article_form.save()
+            article.journal = request.journal
+            article.owner = request.user
+            article.save()
+            return redirect(reverse('bc_add_authors', kwargs={"article_id": article.pk}))
+    else:
+        article_form = ArticleInfo(journal=request.journal,
+                                   additional_fields=additional_fields,)
+        deposit_form = DepositAgreementForm()
+
+    template = 'back_content/article_form.html'
+    context = {
+        'article_form': article_form,
+        'additional_fields': additional_fields,
+        'deposit_form': deposit_form
+    }
+
+    return render(request, template, context)
 
 @editor_user_required
-def article(request, article_id):
+def edit_article(request, article_id):
     article = get_object_or_404(
-        models.Article,
+        Article,
         pk=article_id,
         journal=request.journal,
     )
-    additional_fields = models.Field.objects.filter(
+
+    additional_fields = request.journal.field_set.all()
+    if request.method == 'POST':
+        article_form = ArticleInfo(request.POST,
+                                   additional_fields=additional_fields,
+                                   journal=request.journal,
+                                   instance=article)
+        if article_form.is_valid():
+            article = article_form.save(request=request)
+            article.journal = request.journal
+            article.owner = request.user
+            article.save()
+            if "save_continue" in request.POST:
+                return redirect(reverse('bc_add_authors', kwargs={"article_id": article.pk}))
+            else:
+                return redirect(reverse('bc_index'))
+    else:
+        article_form = ArticleInfo(journal=request.journal,
+                                   additional_fields=additional_fields,
+                                   instance=article)
+
+    template = 'back_content/article_form.html'
+    context = {
+        'article': article,
+        'article_form': article_form,
+        'additional_fields': additional_fields,
+    }
+
+    return render(request, template, context)
+
+@editor_user_required
+def add_authors(request, article_id):
+    article = get_object_or_404(
+        Article,
+        pk=article_id,
         journal=request.journal,
     )
-    article_form = bc_forms.ArticleInfo(
-        instance=article,
-        additional_fields=additional_fields,
-    )
-    author_form = forms.AuthorForm()
-    pub_form = bc_forms.PublicationInfo(instance=article)
-    remote_form = bc_forms.RemoteArticle(instance=article)
-    galley_form = prod_forms.GalleyForm()
-    modal = None
 
-    if request.POST:
-        if 'save_section_1' in request.POST:
-            article_form = bc_forms.ArticleInfo(
-                request.POST,
-                instance=article,
-                additional_fields=additional_fields,
-            )
+    if request.method == "POST":
 
-            if article_form.is_valid():
-                article_form.save()
-                return bc_logic.return_url(
-                    article,
-                    section='section-one',
-                )
+        correspondence_author = request.POST.get('main-author', None)
 
-        if 'save_section_2' in request.POST:
-            correspondence_author = request.POST.get('main-author', None)
-
-            if correspondence_author:
-                author = core_models.Account.objects.get(pk=correspondence_author)
-                article.correspondence_author = author
-                article.save()
-                return bc_logic.return_url(
-                    article,
-                    section='section-two',
-                )
-
-        if 'save_section_4' in request.POST:
-            pub_form = bc_forms.PublicationInfo(request.POST, instance=article)
-
-            if pub_form.is_valid():
-                pub_form.save()
-                if article.primary_issue:
-                    article.primary_issue.articles.add(article)
-
-                if article.date_published:
-                    article.stage = models.STAGE_READY_FOR_PUBLICATION
-                    article.save()
-                return bc_logic.return_url(
-                    article,
-                    section='section-four',
-                )
-
-        if 'save_section_5' in request.POST:
-            remote_form = bc_forms.RemoteArticle(request.POST, instance=article)
-
-            if remote_form.is_valid():
-                remote_form.save()
-                return bc_logic.return_url(
-                    article,
-                    section='section-five',
-                )
-
-        if 'file' in request.FILES:
-            label = request.POST.get('label')
-            for uploaded_file in request.FILES.getlist('file'):
-                prod_logic.save_galley(
-                    article,
-                    request,
-                    uploaded_file,
-                    is_galley=True,
-                    label=label,
-                )
-            return bc_logic.return_url(
-                article,
-                section='section-three',
-            )
-
-        if 'set_main' in request.POST:
-            correspondence_author = request.POST.get('set_main', None)
-
-            if correspondence_author:
-                author = core_models.Account.objects.get(pk=correspondence_author)
-                article.correspondence_author = author
-                article.save()
-                return bc_logic.return_url(
-                    article,
-                    section='section-two',
-                )
+        if correspondence_author:
+            author = Account.objects.get(pk=correspondence_author)
+            article.correspondence_author = author
+            article.save()
 
         if 'add_author' in request.POST:
-            author_form = forms.AuthorForm(request.POST)
-            modal = 'author'
+            author_form = AuthorForm(request.POST)
+            author = check_author_exists(request.POST.get('email'))
 
-            author = logic.check_author_exists(request.POST.get('email'))
             if author:
                 article.authors.add(author)
                 messages.add_message(
@@ -161,7 +144,7 @@ def article(request, article_id):
                 if author_form.is_valid():
                     author = author_form.save(commit=False)
                     author.username = author.email
-                    author.set_password(shared.generate_password())
+                    author.set_password(generate_password())
                     author.save()
                     author.add_account_role(
                         role_slug='author',
@@ -174,28 +157,22 @@ def article(request, article_id):
                         '%s added to the article' % author.full_name(),
                     )
 
-            models.ArticleAuthorOrder.objects.get_or_create(
+            ArticleAuthorOrder.objects.get_or_create(
                 article=article,
                 author=author,
                 defaults={
                     'order': article.next_author_sort(),
                 }
             )
-
-            return bc_logic.return_url(
-                article,
-                section='section-two',
-            )
-
-        if 'remove_author' in request.POST:
+        elif 'remove_author' in request.POST:
             author_pk = request.POST.get('remove_author', None)
             if author_pk:
                 author_to_remove = get_object_or_404(
-                    core_models.Account,
+                    Account,
                     pk=author_pk,
                 )
                 article.authors.remove(author_to_remove)
-                models.ArticleAuthorOrder.objects.filter(
+                ArticleAuthorOrder.objects.filter(
                     article=article,
                     author=author_to_remove,
                 ).delete()
@@ -211,67 +188,122 @@ def article(request, article_id):
                     request,
                     f'No author ID provided.',
                 )
-            return bc_logic.return_url(
-                article,
-                section='section-two',
-            )
+        elif "set_main" in request.POST:
+            correspondence_author = request.POST.get('set_main', None)
 
-        if 'publish' in request.POST:
-            crossref_enabled = request.journal.get_setting(
-                'Identifiers',
-                'use_crossref',
-            )
-            if not article.stage == models.STAGE_PUBLISHED:
-                if crossref_enabled:
-                    id_logic.generate_crossref_doi_with_pattern(article)
-                article.stage = models.STAGE_PUBLISHED
-                article.snapshot_authors(article)
+            if correspondence_author:
+                author = Account.objects.get(pk=correspondence_author)
+                article.correspondence_author = author
                 article.save()
-
-            if plugin_settings.IS_WORKFLOW_PLUGIN:
-                workflow_kwargs = {'handshake_url': 'bc_article',
-                                   'request': request,
-                                   'article': article,
-                                   'switch_stage': True}
-                return event_logic.Events.raise_event(event_logic.Events.ON_WORKFLOW_ELEMENT_COMPLETE,
-                                                      task_object=article,
-                                                      **workflow_kwargs)
+        else:
+            if "continue" in request.POST:
+                return redirect(reverse('bc_add_galleys', kwargs={"article_id": article.pk}))
+            elif "back" in request.POST:
+                return redirect(reverse('bc_edit_article', kwargs={"article_id": article.pk}))
             else:
                 return redirect(reverse('bc_index'))
+    else:
+        author_form = AuthorForm()
 
-    template = 'back_content/article.html'
     context = {
         'article': article,
-        'article_form': article_form,
         'form': author_form,
+    }
+    return render(request, "back_content/author_form.html", context)
+
+
+@editor_user_required
+def add_galleys(request, article_id):
+    article = get_object_or_404(
+        Article,
+        pk=article_id,
+        journal=request.journal,
+    )
+    galley_form = GalleyForm()
+    if request.method == "POST":
+        if "file" in request.FILES:
+            label = request.POST.get('label')
+            for uploaded_file in request.FILES.getlist('file'):
+                save_galley(
+                    article,
+                    request,
+                    uploaded_file,
+                    is_galley=True,
+                    label=label,
+                )
+        elif "continue" in request.POST:
+            return redirect(reverse('bc_publish_article', kwargs={"article_id": article.pk}))
+        elif "close" in request.POST:
+            return redirect(reverse('bc_index'))
+        elif "back" in request.POST:
+            return redirect(reverse('bc_add_authors', kwargs={"article_id": article.pk}))
+
+    context = {
+        "article": article,
+        'galleys': get_all_galleys(article),
+        "galley_form": galley_form
+    }
+    return render(request, "back_content/galley_form.html", context)
+
+
+@editor_user_required
+def publish(request, article_id):
+    article = get_object_or_404(
+        Article,
+        pk=article_id,
+        journal=request.journal,
+    )
+
+    if request.method == 'POST':
+        print(request.POST)
+        pub_form = PublicationInfo(request.POST, 
+                                   instance=article)
+        if pub_form.is_valid():
+            article = pub_form.save()
+            
+            print(article.primary_issue)
+            if article.primary_issue:
+                article.primary_issue.articles.add(article)
+                article.save()
+
+            if 'save_close' in request.POST:
+                return redirect('bc_index')
+            elif 'publish' in request.POST:
+                if not article.stage == STAGE_PUBLISHED:
+                    article.stage = STAGE_PUBLISHED
+                    article.snapshot_authors(article)
+                    article.save()
+                return redirect('bc_index')
+            else:
+                return redirect('bc_create_article')
+    else:
+        pub_form = PublicationInfo(instance=article)
+
+    template = 'back_content/publish_form.html'
+    context = {
         'pub_form': pub_form,
-        'galleys': prod_logic.get_all_galleys(article),
-        'remote_form': remote_form,
-        'modal': modal,
-        'galley_form': galley_form,
-        'additional_fields': additional_fields,
+        'article': article
     }
 
     return render(request, template, context)
 
-
 @editor_user_required
 def doi_import(request):
-    form = bc_forms.RemoteParse()
+    form = RemoteParse()
 
     if request.POST:
-        form = bc_forms.RemoteParse(request.POST)
+        form = RemoteParse(request.POST)
         if form.is_valid():
             url = form.cleaned_data['url']
             mode = form.cleaned_data['mode']
 
             if mode == 'doi':
                 r = requests.get('https://api.crossref.org/v1/works/{0}'.format(url)).json()
-                article = bc_logic.get_and_parse_doi_metadata(r, request, doi=url)
+                article = get_and_parse_doi_metadata(r, request, doi=url)
                 return redirect(reverse('bc_article', kwargs={'article_id': article.pk}))
             else:
                 r = requests.get(url)
-                article = bc_logic.parse_url_results(r, request)
+                article = parse_url_results(r, request)
                 return redirect(reverse('bc_article', kwargs={'article_id': article.pk}))
 
     template = 'back_content/doi_import.html'
@@ -280,7 +312,6 @@ def doi_import(request):
     }
 
     return render(request, template, context)
-
 
 @editor_user_required
 def preview_xml_galley(request, article_id, galley_id):
@@ -292,13 +323,13 @@ def preview_xml_galley(request, article_id, galley_id):
     :return: HttpResponse
     """
 
-    article = get_object_or_404(models.Article, journal=request.journal, pk=article_id)
-    galley = core_models.Galley.objects.filter(article=article, file__mime_type__contains='/xml', pk=galley_id)
+    article = get_object_or_404(Article, journal=request.journal, pk=article_id)
+    galley = Galley.objects.filter(article=article, file__mime_type__contains='/xml', pk=galley_id)
 
     if not galley:
         raise Http404
 
-    content = journal_logic.get_galley_content(article, galley)
+    content = get_galley_content(article, galley)
 
     template = 'journal/article.html'
     context = {
@@ -309,18 +340,14 @@ def preview_xml_galley(request, article_id, galley_id):
 
     return render(request, template, context)
 
-
-from core.views import BaseUserList
-
-
 class BCPAuthorSearch(BaseUserList):
 
-    model = core_models.Account
+    model = Account
     template_name = 'back_content/author_search.html'
 
     def dispatch(self, request, *args, **kwargs):
         self.article = get_object_or_404(
-            models.Article,
+            Article,
             pk=kwargs.get('article_id'),
             journal=request.journal,
         )
@@ -366,12 +393,12 @@ class BCPAuthorSearch(BaseUserList):
         if "add_author" in request.POST:
             author_id = request.POST.get("add_author")
             author = get_object_or_404(
-                core_models.Account,
+                Account,
                 pk=author_id,
             )
             if author in self.get_queryset():
                 self.article.authors.add(author)
-                models.ArticleAuthorOrder.objects.get_or_create(
+                ArticleAuthorOrder.objects.get_or_create(
                     article=self.article,
                     author=author,
                     defaults={

--- a/views.py
+++ b/views.py
@@ -63,7 +63,7 @@ def create_article(request):
                                    journal=request.journal)
         deposit_form = DepositAgreementForm(request.POST)
         if article_form.is_valid() and deposit_form.is_valid():
-            article = article_form.save()
+            article = article_form.save(request=request)
             article.journal = request.journal
             article.owner = request.user
             article.save()

--- a/views.py
+++ b/views.py
@@ -32,6 +32,8 @@ from plugins.back_content.logic import (get_and_parse_doi_metadata,
                                         parse_url_results)
 
 from utils.shared import generate_password
+from utils import setting_handler
+from identifiers.logic import generate_crossref_doi_with_pattern
 
 
 @editor_user_required
@@ -273,6 +275,10 @@ def publish(request, article_id):
                 return redirect('bc_index')
             elif 'publish' in request.POST:
                 if not article.stage == STAGE_PUBLISHED:
+                    if article.journal.get_setting('plugin:ezid',
+                                                   'ezid_plugin_enable'):
+                        if not article.get_doi():
+                            _id = generate_crossref_doi_with_pattern(article)
                     article.stage = STAGE_PUBLISHED
                     article.snapshot_authors(article)
                     article.save()

--- a/views.py
+++ b/views.py
@@ -252,6 +252,11 @@ def publish(request, article_id):
                 article.save()
 
             if 'save_close' in request.POST:
+                messages.add_message(
+                    request,
+                    messages.SUCCESS,
+                    _(f'{article} saved.'),
+                )
                 return redirect('bc_index')
             elif 'back' in request.POST:
                 return redirect(reverse('bc_add_galleys', kwargs={"article_id": article.pk}))
@@ -264,6 +269,11 @@ def publish(request, article_id):
                     article.stage = STAGE_PUBLISHED
                     article.snapshot_authors(article)
                     article.save()
+                    messages.add_message(
+                        request,
+                        messages.SUCCESS,
+                        _(f'{article} published.'),
+                    )
                 return redirect(reverse('manage_archive_article', kwargs={"article_id": article.pk}))
             else:
                 return redirect(reverse('bc_create_article'))

--- a/views.py
+++ b/views.py
@@ -196,24 +196,19 @@ def add_galleys(request, article_id):
     supp_form = FileDetails()
 
     if request.method == "POST":
-        print(request.POST)
-        print(request.FILES)
         if "supp-file" in request.FILES:
             label = request.POST.get('label')
             for uploaded_file in request.FILES.getlist('supp-file'):
-                print("add supp file")
                 save_supp_file(
                     article,
                     request,
                     uploaded_file,
                     label
                 )
-                print(article.supplementary_files.all())
             return redirect(reverse('bc_add_galleys', kwargs={"article_id": article.pk}))
         elif "file" in request.FILES:
             label = request.POST.get('label')
             for uploaded_file in request.FILES.getlist('file'):
-                print("add galley")
                 save_galley(
                     article,
                     request,

--- a/views.py
+++ b/views.py
@@ -34,6 +34,7 @@ from plugins.back_content.logic import (get_and_parse_doi_metadata,
                                         parse_url_results)
 
 from identifiers.logic import generate_crossref_doi_with_pattern
+from events.logic import Events
 
 @editor_user_required
 def index(request):
@@ -269,6 +270,13 @@ def publish(request, article_id):
                     article.stage = STAGE_PUBLISHED
                     article.snapshot_authors(article)
                     article.save()
+                    kwargs = {'article': article,
+                              'request': request}
+                    Events.raise_event(
+                        Events.ON_ARTICLE_PUBLISHED,
+                        task_object=article,
+                        **kwargs,
+                    )
                     messages.add_message(
                         request,
                         messages.SUCCESS,


### PR DESCRIPTION
- Rework forms into multiple views to prevent loss of data
- Add deposit agreement
- Remove remote section and other instructions that don't apply to us
- Also fix bugs in janeway PR, remove unused column and set owner
- Allow users to attach supplemental files
- Use frozen authors instead of account-based authors
- Raise publish event when publish button pressed