### PR TITLE
use field defaults, required date published and issue

### DIFF
--- a/views.py
+++ b/views.py
@@ -244,8 +244,7 @@ def publish(request, article_id):
 
     if request.method == 'POST':
         pub_form = PublicationInfo(request.POST, 
-                                   instance=article,
-                                   is_publish=('publish' in request.POST))
+                                   instance=article)
         if pub_form.is_valid():
             article = pub_form.save()
             


### PR DESCRIPTION
- Use journal configured defaults for language, section and license
- Require date published and issue in publication form regardless of button pressed